### PR TITLE
Replace gorilla/mux with Go 1.22 standard library routing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/st3fan/wec-ca
 
-go 1.21
-
-require github.com/gorilla/mux v1.8.0
+go 1.22

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=


### PR DESCRIPTION
## Summary
- Remove gorilla/mux dependency and migrate to Go 1.22 standard library HTTP routing
- Use http.NewServeMux() with method+path patterns (e.g., "GET /path")
- Replace mux.Vars() with r.PathValue()
- Fix serverURL construction to properly include port from address
- Update go.mod to require Go 1.22

## Test plan
- [ ] Verify all ACME endpoints respond correctly with new routing
- [ ] Test directory endpoint includes correct URLs with ports
- [ ] Confirm path parameters are extracted properly in handlers
- [ ] Validate middleware still functions correctly
- [ ] Test certificate ordering and finalization flows

🤖 Generated with [Claude Code](https://claude.ai/code)