### PR TITLE
Fix HTTP 405 error for certificate download endpoint

### DIFF
--- a/application.go
+++ b/application.go
@@ -98,6 +98,7 @@ func (app *Application) run() error {
 	mux.HandleFunc("POST /acme/new-order", app.handleNewOrder)
 	mux.HandleFunc("GET /acme/order/{orderID}", app.handleOrder)
 	mux.HandleFunc("POST /acme/finalize/{orderID}", app.handleFinalize)
+	mux.HandleFunc("POST /acme/cert/{orderID}", app.handleCertificate)
 	mux.HandleFunc("GET /acme/cert/{orderID}", app.handleCertificate)
 
 	// Static files


### PR DESCRIPTION
## Summary

This PR fixes the "HTTP 405: Method Not Allowed" error that occurs when Caddy and other ACME clients try to download certificates from the ACME server.

## Problem

The error in the Caddy logs shows:
```
request to https://acme.sateh.systems:8443/acme/cert/order_1751289836789530881 failed after 1 attempts: HTTP 405: Method Not Allowed
```

This happens because the certificate download endpoint was only configured to accept GET requests, but Caddy was making POST requests.

## Root Cause

The certificate endpoint `/acme/cert/{orderID}` was only configured for GET method:
```go
mux.HandleFunc("GET /acme/cert/{orderID}", app.handleCertificate)
```

However, different ACME clients use different HTTP methods for certificate downloads.

## Solution

Added support for both GET and POST methods on the certificate download endpoint:
```go
mux.HandleFunc("POST /acme/cert/{orderID}", app.handleCertificate)
mux.HandleFunc("GET /acme/cert/{orderID}", app.handleCertificate)
```

## RFC 8555 Compliance

According to RFC 8555 (ACME specification), certificate downloads can use either:
- **GET requests**: For simple, unauthenticated downloads
- **POST requests**: For authenticated downloads (more common with ACME clients)

Supporting both methods ensures maximum compatibility with different ACME client implementations.

## Benefits

1. **Fixes Caddy Integration**: Resolves the HTTP 405 error when Caddy downloads certificates
2. **Broader Compatibility**: Works with ACME clients that prefer either GET or POST
3. **RFC Compliant**: Follows ACME specification guidelines
4. **No Breaking Changes**: Existing GET functionality continues to work

## Test Plan

- [x] All existing tests pass
- [x] Certificate endpoint now accepts both GET and POST methods
- [x] `handleCertificate` function unchanged (works for both methods)
- [x] No impact on other ACME endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)