### PR TITLE
Remove Dockerfile from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,6 @@ data/
 wec-ca
 
 # Docker files
-Dockerfile
 .dockerignore
 
 # IDE files


### PR DESCRIPTION
## Summary
- Remove Dockerfile from .dockerignore to allow it in Docker build context
- Enables proper multi-stage builds that may reference the Dockerfile

## Test plan
- [ ] Verify Docker builds still work correctly
- [ ] Confirm Dockerfile is now included in build context

🤖 Generated with [Claude Code](https://claude.ai/code)