### PR TITLE
Improve storage constructors to handle directory creation upfront

### DIFF
--- a/account_storage.go
+++ b/account_storage.go
@@ -20,17 +20,17 @@ type FilesystemAccountStorage struct {
 	dataDir string
 }
 
-func NewFilesystemAccountStorage(dataDir string) *FilesystemAccountStorage {
+func NewFilesystemAccountStorage(dataDir string) (*FilesystemAccountStorage, error) {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create accounts directory: %v", err)
+	}
+	
 	return &FilesystemAccountStorage{
 		dataDir: dataDir,
-	}
+	}, nil
 }
 
 func (fs *FilesystemAccountStorage) Create(account *Account) error {
-	if err := os.MkdirAll(fs.dataDir, 0755); err != nil {
-		return fmt.Errorf("failed to create accounts directory: %v", err)
-	}
-
 	filename := fmt.Sprintf("%d.json", time.Now().UnixNano())
 	filePath := filepath.Join(fs.dataDir, filename)
 

--- a/application.go
+++ b/application.go
@@ -68,14 +68,24 @@ type Directory struct {
 	KeyChange  string `json:"keyChange"`
 }
 
-func newApplication(settings *Settings) *Application {
+func newApplication(settings *Settings) (*Application, error) {
+	accountStorage, err := NewFilesystemAccountStorage(filepath.Join(dataDir, "accounts"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize account storage: %v", err)
+	}
+	
+	orderStorage, err := NewFilesystemOrderStorage(filepath.Join(dataDir, "orders"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize order storage: %v", err)
+	}
+	
 	return &Application{
 		settings:       settings,
-		accountStorage: NewFilesystemAccountStorage(filepath.Join(dataDir, "accounts")),
-		orderStorage:   NewFilesystemOrderStorage(filepath.Join(dataDir, "orders")),
+		accountStorage: accountStorage,
+		orderStorage:   orderStorage,
 		nonceGen:       NewCryptoNonceGenerator(16), // 16 bytes = 128 bits of entropy
 		nonceStorage:   NewInMemoryNonceStorage(time.Hour, 10*time.Minute), // 1 hour TTL, cleanup every 10 minutes
-	}
+	}, nil
 }
 
 func (app *Application) run() error {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,11 @@ func main() {
 	}
 	
 	// Create and run application
-	app := newApplication(settings)
+	app, err := newApplication(settings)
+	if err != nil {
+		log.Fatalf("Failed to create application: %v", err)
+	}
+	
 	if err := app.run(); err != nil {
 		log.Fatalf("Application failed: %v", err)
 	}

--- a/order_storage.go
+++ b/order_storage.go
@@ -20,17 +20,17 @@ type FilesystemOrderStorage struct {
 	dataDir string
 }
 
-func NewFilesystemOrderStorage(dataDir string) *FilesystemOrderStorage {
+func NewFilesystemOrderStorage(dataDir string) (*FilesystemOrderStorage, error) {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create orders directory: %v", err)
+	}
+	
 	return &FilesystemOrderStorage{
 		dataDir: dataDir,
-	}
+	}, nil
 }
 
 func (fs *FilesystemOrderStorage) Create(order *Order) error {
-	if err := os.MkdirAll(fs.dataDir, 0755); err != nil {
-		return fmt.Errorf("failed to create orders directory: %v", err)
-	}
-
 	filename := fmt.Sprintf("%d.json", time.Now().UnixNano())
 	filePath := filepath.Join(fs.dataDir, filename)
 


### PR DESCRIPTION
## Summary
- Update both `NewFilesystemAccountStorage` and `NewFilesystemOrderStorage` to return errors
- Move directory creation (`os.MkdirAll`) from `Create()` methods to constructors
- Update `newApplication` to handle constructor errors and return error
- Update `main.go` to handle application creation errors

## Benefits
- **Fail fast**: Directory creation issues are caught at startup rather than on first use
- **Better error handling**: Constructor errors are properly propagated to main
- **Cleaner design**: Directory creation happens once during initialization, not on every Create call
- **Consistent pattern**: Both storage implementations follow the same error-returning constructor pattern

## Changes
- `NewFilesystemAccountStorage(dataDir) (*FilesystemAccountStorage, error)`
- `NewFilesystemOrderStorage(dataDir) (*FilesystemOrderStorage, error)`
- `newApplication(settings) (*Application, error)`
- Removed redundant `os.MkdirAll` calls from `Create()` methods

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [ ] Test startup with invalid directory permissions
- [ ] Verify directories are created at startup
- [ ] Test Create operations work without redundant directory creation

🤖 Generated with [Claude Code](https://claude.ai/code)