### PR TITLE
Rename HTTP handlers to include method names for clarity

### DIFF
--- a/application.go
+++ b/application.go
@@ -100,8 +100,7 @@ func (app *Application) run() error {
 	mux.HandleFunc("POST /acme/new-order", app.handlePostNewOrder)
 	mux.HandleFunc("GET /acme/order/{orderID}", app.handleGetOrder)
 	mux.HandleFunc("POST /acme/finalize/{orderID}", app.handlePostFinalize)
-	mux.HandleFunc("POST /acme/cert/{orderID}", app.handleCertificate)
-	mux.HandleFunc("GET /acme/cert/{orderID}", app.handleCertificate)
+	mux.HandleFunc("POST /acme/cert/{orderID}", app.handlePostCertificate)
 
 	// Static files
 	mux.HandleFunc("GET /ca.crt", app.handleGetCACert)

--- a/application.go
+++ b/application.go
@@ -93,8 +93,8 @@ func (app *Application) run() error {
 
 	// ACME endpoints
 	mux.HandleFunc("GET /acme/directory", app.handleGetDirectory)
-	mux.HandleFunc("HEAD /acme/new-nonce", app.handleNewNonce)
-	mux.HandleFunc("GET /acme/new-nonce", app.handleNewNonce)
+	mux.HandleFunc("HEAD /acme/new-nonce", app.handleHeadNewNonce)
+	mux.HandleFunc("GET /acme/new-nonce", app.handleGetNewNonce)
 	mux.HandleFunc("POST /acme/new-account", app.handlePostNewAccount)
 	mux.HandleFunc("GET /acme/account/{accountID}", app.handleGetAccount)
 	mux.HandleFunc("POST /acme/new-order", app.handlePostNewOrder)

--- a/application.go
+++ b/application.go
@@ -92,19 +92,19 @@ func (app *Application) run() error {
 	mux := http.NewServeMux()
 
 	// ACME endpoints
-	mux.HandleFunc("GET /acme/directory", app.handleDirectory)
+	mux.HandleFunc("GET /acme/directory", app.handleGetDirectory)
 	mux.HandleFunc("HEAD /acme/new-nonce", app.handleNewNonce)
 	mux.HandleFunc("GET /acme/new-nonce", app.handleNewNonce)
-	mux.HandleFunc("POST /acme/new-account", app.handleNewAccount)
-	mux.HandleFunc("GET /acme/account/{accountID}", app.handleAccount)
-	mux.HandleFunc("POST /acme/new-order", app.handleNewOrder)
-	mux.HandleFunc("GET /acme/order/{orderID}", app.handleOrder)
-	mux.HandleFunc("POST /acme/finalize/{orderID}", app.handleFinalize)
+	mux.HandleFunc("POST /acme/new-account", app.handlePostNewAccount)
+	mux.HandleFunc("GET /acme/account/{accountID}", app.handleGetAccount)
+	mux.HandleFunc("POST /acme/new-order", app.handlePostNewOrder)
+	mux.HandleFunc("GET /acme/order/{orderID}", app.handleGetOrder)
+	mux.HandleFunc("POST /acme/finalize/{orderID}", app.handlePostFinalize)
 	mux.HandleFunc("POST /acme/cert/{orderID}", app.handleCertificate)
 	mux.HandleFunc("GET /acme/cert/{orderID}", app.handleCertificate)
 
 	// Static files
-	mux.HandleFunc("GET /ca.crt", app.handleCACert)
+	mux.HandleFunc("GET /ca.crt", app.handleGetCACert)
 
 	// Wrap with logging middleware
 	handler := app.logRequest(mux)

--- a/handlers.go
+++ b/handlers.go
@@ -452,7 +452,7 @@ func (app *Application) handlePostFinalize(w http.ResponseWriter, r *http.Reques
 	json.NewEncoder(w).Encode(order)
 }
 
-func (app *Application) handleCertificate(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handlePostCertificate(w http.ResponseWriter, r *http.Request) {
 	orderID := r.PathValue("orderID")
 
 	certFile := filepath.Join(dataDir, orderID+".crt")

--- a/handlers.go
+++ b/handlers.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-func (app *Application) handleDirectory(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handleGetDirectory(w http.ResponseWriter, r *http.Request) {
 	dir := Directory{
 		NewNonce:   app.settings.ServerURL + "/acme/new-nonce",
 		NewAccount: app.settings.ServerURL + "/acme/new-account",
@@ -110,7 +110,7 @@ func (app *Application) validateNonce(w http.ResponseWriter, jwsReq map[string]i
 	return true
 }
 
-func (app *Application) handleNewAccount(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handlePostNewAccount(w http.ResponseWriter, r *http.Request) {
 	// Read the raw body
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -234,7 +234,7 @@ func (app *Application) handleNewAccount(w http.ResponseWriter, r *http.Request)
 	json.NewEncoder(w).Encode(account)
 }
 
-func (app *Application) handleAccount(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 	accountID := r.PathValue("accountID")
 
 	account, err := app.accountStorage.Read(accountID)
@@ -247,7 +247,7 @@ func (app *Application) handleAccount(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(account)
 }
 
-func (app *Application) handleNewOrder(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handlePostNewOrder(w http.ResponseWriter, r *http.Request) {
 	// Read the raw body first for logging
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -349,7 +349,7 @@ func (app *Application) handleNewOrder(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(order)
 }
 
-func (app *Application) handleOrder(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handleGetOrder(w http.ResponseWriter, r *http.Request) {
 	orderID := r.PathValue("orderID")
 
 	order, err := app.orderStorage.Read(orderID)
@@ -362,7 +362,7 @@ func (app *Application) handleOrder(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(order)
 }
 
-func (app *Application) handleFinalize(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handlePostFinalize(w http.ResponseWriter, r *http.Request) {
 	orderID := r.PathValue("orderID")
 
 	order, err := app.orderStorage.Read(orderID)
@@ -467,7 +467,7 @@ func (app *Application) handleCertificate(w http.ResponseWriter, r *http.Request
 	w.Write(certData)
 }
 
-func (app *Application) handleCACert(w http.ResponseWriter, r *http.Request) {
+func (app *Application) handleGetCACert(w http.ResponseWriter, r *http.Request) {
 	certData, err := os.ReadFile(caCertFile)
 	if err != nil {
 		http.Error(w, "CA certificate not found", http.StatusNotFound)


### PR DESCRIPTION
## Summary
- Rename HTTP handlers to include the HTTP method in the function name for better clarity
- Split handlers that previously handled multiple methods into dedicated method-specific handlers
- Update all corresponding route registrations in application.go
- Improve code readability and make handler purposes more explicit

## Changes
- `handleDirectory` → `handleGetDirectory` (GET /acme/directory)
- `handleNewNonce` → `handleGetNewNonce` + `handleHeadNewNonce` (GET/HEAD /acme/new-nonce)
- `handleNewAccount` → `handlePostNewAccount` (POST /acme/new-account)
- `handleAccount` → `handleGetAccount` (GET /acme/account/{accountID})
- `handleNewOrder` → `handlePostNewOrder` (POST /acme/new-order)
- `handleOrder` → `handleGetOrder` (GET /acme/order/{orderID})
- `handleFinalize` → `handlePostFinalize` (POST /acme/finalize/{orderID})
- `handleCertificate` → `handlePostCertificate` (POST /acme/cert/{orderID} only)
- `handleCACert` → `handleGetCACert` (GET /ca.crt)

## Key Improvements
- **Method-specific handlers**: Each handler now handles exactly one HTTP method
- **Clearer intent**: Function names explicitly indicate the HTTP method and purpose
- **Better organization**: Easier to identify which handlers serve which methods
- **RFC compliance**: Proper status codes for GET (204) vs HEAD (200) nonce requests
- **Certificate endpoint**: Now POST-only as per ACME RFC 8555 specification

## Handler Status Codes
- `handleGetNewNonce`: Returns 204 NoContent
- `handleHeadNewNonce`: Returns 200 OK
- `handlePostCertificate`: POST-only, removed GET support

## Benefits
- **Improved maintainability**: Less ambiguity when working with the codebase
- **Better debugging**: Easier to trace issues to specific HTTP methods
- **Code clarity**: Each function has a single, clear responsibility
- **Standards alignment**: Better adherence to ACME protocol specifications

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [ ] Verify all ACME endpoints still function correctly
- [ ] Test nonce generation with both GET and HEAD requests
- [ ] Confirm certificate endpoint only responds to POST
- [ ] Validate proper HTTP status codes for each endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)